### PR TITLE
fix/paginacion para roles y usuarios - se limitan los repositorios a sus respectivos modulos, haciendo uso de include para traer informacion relacionada

### DIFF
--- a/src/roles/repositories/IRoleRepository.ts
+++ b/src/roles/repositories/IRoleRepository.ts
@@ -6,9 +6,11 @@ export interface IRoleRepository {
   findById(id: string): Promise<Role | null>;
   findByName(name: string): Promise<Role | null>;
   findAll(): Promise<Role[]>;
+  table(page: number, size: number): Promise<Role[]>;
   delete(id: string): Promise<void>;
   assignRoleToUser(data: UserRole): Promise<UserRole>;
   removeRoleFromUser(data: UserRole): Promise<void>;
   findRolesByUserId(userId: string): Promise<UserRole[]>;
+  findRolesByIds(userId: string, roleId: string): Promise<UserRole>;
   findRoleNamesByUserId(userId: string): Promise<string[]>;
 }

--- a/src/roles/repositories/RoleRepositoryPrisma.ts
+++ b/src/roles/repositories/RoleRepositoryPrisma.ts
@@ -26,6 +26,10 @@ export class RoleRepositoryPrisma implements IRoleRepository {
     return await prisma.role.findMany();
   }
 
+  async table(page: number, size: number) {
+    return await prisma.role.findMany({ skip: (page - 1) * size, take: size });
+  }
+
   async delete(id: string) {
     await prisma.role.delete({
       where: { id },
@@ -61,20 +65,22 @@ export class RoleRepositoryPrisma implements IRoleRepository {
     return userRoles;
   }
 
+  async findRolesByIds(userId: string, roleId: string): Promise<UserRole> {
+    const userRoles = await prisma.userRoles.findUnique({
+      where: { userId_roleId: { userId, roleId } },
+    });
+
+    return userRoles;
+  }
+
   async findRoleNamesByUserId(userId: string): Promise<string[]> {
     const userRoles = await prisma.userRoles.findMany({
       where: { userId },
+      include: {
+        role: true,
+      },
     });
 
-    const roles = [];
-
-    for (const userRole of userRoles) {
-      const role = await prisma.role.findUnique({
-        where: { id: userRole.roleId },
-      });
-      roles.push(role);
-    }
-
-    return roles.map((r) => r.name);
+    return userRoles.map((r) => r.role.name);
   }
 }

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -21,6 +21,14 @@ export class RoleController {
     return res.status(200).json(roles);
   }
 
+  async table(req: Request, res: Response): Promise<Response> {
+    const page = req.query.page ? parseInt(req.query.page as string, 10) : 1;
+    const size = req.query.size ? parseInt(req.query.size as string, 10) : 10;
+
+    const roles = await this.roleService.table(page, size);
+    return res.status(200).json(roles);
+  }
+
   async delete(req: Request, res: Response): Promise<Response> {
     await this.roleService.delete(req.params.id);
     return res.status(204).send();

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -37,6 +37,14 @@ export class RoleService {
     return this.roleRepository.findAll();
   }
 
+  async table(page: number, size: number) {
+    if (page <= 0 || size <= 0) {
+      throw new ApiError("Los datos de paginacion no son validos", 400, []);
+    }
+
+    return this.roleRepository.table(page, size);
+  }
+
   async delete(id: string) {
     const existing = await this.roleRepository.findById(id);
     if (!existing) {
@@ -59,15 +67,12 @@ export class RoleService {
       throw new ApiError("El usuario especificado no existe", 404, []);
     }
 
-    const userRoles = await this.roleRepository.findRolesByUserId(
-      dtoValidated.userId
+    const userRoles = await this.roleRepository.findRolesByIds(
+      dtoValidated.userId,
+      dtoValidated.roleId
     );
 
-    const roleAlreadyAssigned = userRoles.some(
-      (ur) => ur.roleId === dtoValidated.roleId
-    );
-
-    if (roleAlreadyAssigned) {
+    if (userRoles) {
       throw new ApiError("El usuario ya posee dicho rol", 404, []);
     }
 

--- a/src/users/repositories/IUserRepository.ts
+++ b/src/users/repositories/IUserRepository.ts
@@ -6,5 +6,5 @@ export interface IUserRepository {
   findById(id: string): Promise<UserWithoutPassword | null>;
   update(id: string, data: Partial<User>): Promise<User>;
   delete(id: string): Promise<void>;
-  findAll(): Promise<UserWithoutPassword[] | null>;
+  findAll(page: number, size: number): Promise<UserWithoutPassword[] | null>;
 }

--- a/src/users/repositories/UserRepositoryPrisma.ts
+++ b/src/users/repositories/UserRepositoryPrisma.ts
@@ -8,12 +8,26 @@ export class UserRepositoryPrisma implements IUserRepository {
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    return await prisma.user.findUnique({ where: { email } });
+    return await prisma.user.findUnique({
+      where: { email },
+      include: {
+        UserRoles: {
+          include: {
+            role: true,
+          },
+        },
+      },
+    });
   }
 
-  async findAll(): Promise<UserWithoutPassword[] | null> {
+  async findAll(
+    page: number,
+    size: number
+  ): Promise<UserWithoutPassword[] | null> {
     return await prisma.user.findMany({
       select: { id: true, nombre: true, email: true, fechaCreacion: true },
+      skip: (page - 1) * size,
+      take: size,
     });
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,7 +17,10 @@ export class UserController {
   }
 
   async findAll(req: Request, res: Response): Promise<Response> {
-    const response = await this.userService.findAll();
+    const page = req.query.page ? parseInt(req.query.page as string, 10) : 1;
+    const size = req.query.size ? parseInt(req.query.size as string, 10) : 10;
+
+    const response = await this.userService.findAll(page, size);
     return res.status(200).json(response);
   }
 
@@ -43,6 +46,7 @@ export class UserController {
       req.params.id,
       req.body
     );
+
     return res.status(200).json(result);
   }
 }

--- a/src/users/users.routes.ts
+++ b/src/users/users.routes.ts
@@ -6,18 +6,13 @@ import { UserService } from "./users.service";
 import { Controller } from "../common/decorators/controllers.decorator";
 import { UserRepositoryPrisma } from "./repositories/UserRepositoryPrisma";
 import { VerifyToken } from "../common/decorators/verifyToken.decorator";
-import { RoleRepositoryPrisma } from "../roles/repositories/RoleRepositoryPrisma";
 
 @Controller("/users")
 export class UsersRoutes {
   public static router: Router;
 
-  protected roleRepository = new RoleRepositoryPrisma();
   protected userRepository = new UserRepositoryPrisma();
-  protected userService = new UserService(
-    this.userRepository,
-    this.roleRepository
-  );
+  protected userService = new UserService(this.userRepository);
   protected userController = new UserController(this.userService);
 
   @Route("/", "post")

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,13 +9,9 @@ import { validateDto } from "../common/utils/validateDto";
 import { ApiError } from "../common/errors/apiError";
 import bcrypt from "bcrypt";
 import jwt from "../common/utils/jwt";
-import { IRoleRepository } from "roles/repositories/IRoleRepository";
 
 export class UserService {
-  constructor(
-    private userRepository: IUserRepository,
-    private roleRepository: IRoleRepository
-  ) {}
+  constructor(private userRepository: IUserRepository) {}
 
   async create(dto: CreateUserDto) {
     const dtoValidate = await validateDto(CreateUserDto, dto);
@@ -46,8 +42,12 @@ export class UserService {
     return user;
   }
 
-  async findAll() {
-    return this.userRepository.findAll();
+  async findAll(page: number, size: number) {
+    if (page <= 0 || size <= 0) {
+      throw new ApiError("Los datos de paginacion no son validos", 400, []);
+    }
+
+    return this.userRepository.findAll(page, size);
   }
 
   async update(id: string, dto: UpdateUserDto) {
@@ -94,7 +94,7 @@ export class UserService {
       throw new ApiError("Contraseña incorrecta", 400, []);
     }
 
-    const roles = await this.roleRepository.findRoleNamesByUserId(user.id);
+    const roles = user["UserRoles"].map((r) => r.role.name);
 
     const token: any = jwt.sign({
       id: user.id,


### PR DESCRIPTION
Se agrego la paginación para la incorporación de tables y evitar la recuperación de toda la existencia de información en la base de datos:

Usuarios:
![image](https://github.com/user-attachments/assets/ecdcfd21-c9a3-414b-a9ca-ef0e7c5d83b2)

Roles:
![image](https://github.com/user-attachments/assets/0ea57833-970e-44be-828a-9ea59787f01f)

Se hace uso de include para que cada repositorio pertenezca a su propio modulo y evitar multiples llamadas a la base de datos:
![image](https://github.com/user-attachments/assets/e67b6ef9-d628-4468-a0b2-b0d242d2a8c9)

